### PR TITLE
Created enum for edge types

### DIFF
--- a/preciceconfiggraph/edges.py
+++ b/preciceconfiggraph/edges.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class Edge(Enum):
+    RECEIVE_MESH = "receive-mesh"
+    PROVIDE_MESH = "provide-mesh"
+
+    MAPPING = "mapping"
+    EXCHANGE = "exchange"
+    SOCKET = "socket"
+    COUPLING_SCHEME = "coupling-scheme"
+
+    USE_DATA = "use-data"
+    WRITE_DATA = "write-data"
+    READ_DATA = "read-data"


### PR DESCRIPTION
The graph should handle origin and destination, so it should suffice adding edge types as enums to make checking for missing / redundant edges easier.