### PR TITLE
add type and constraints to mapping nodes

### DIFF
--- a/docs/Nodes.md
+++ b/docs/Nodes.md
@@ -86,6 +86,8 @@ another.
 
 - `parent_participant`: This links to the participant that specifies the mapping.
 - `direction`: This specifies the direction of the data mapping.
+- `just-in-time`: A bool, which indicates, if the mapping is a "just-in-time"-mapping. A JIT mapping is missing either
+  the `to` or `from` tag.
 - `from_mesh`: The mesh as specified in the `from=“”` tag
 - `to_mesh`: The mesh as specified in the `to=“”` tag
 
@@ -126,7 +128,7 @@ Export nodes are another way a user can receive data from a coupled simulation u
 ## Action
 
 - `participant`: The participant specifying this action.
-- `type`: The type of the action, as specified by `<action:…` …/>. Possible values are `multiply-by-area`, 
+- `type`: The type of the action, as specified by `<action:…` …/>. Possible values are `multiply-by-area`,
   `divide-by-area`, `summation` and `python`.
 - `mesh`: The mesh this action will operate on.
 - `timing`: When this action will be executed. One value is `write-mapping-post`, the other `read-mapping-post`.
@@ -153,7 +155,7 @@ participants.
 
 ## M2N
 
-To let participants exchange information (physically), they have to be connected via an m2n node. 
+To let participants exchange information (physically), they have to be connected via an m2n node.
 
 - `type`: The type of the m2n node. Possible values are `sockets`, `mpi` and `mpi-multiple-ports`.
 - `acceptor`: The participant defined as `acceptor=...`.

--- a/docs/Nodes.md
+++ b/docs/Nodes.md
@@ -88,8 +88,10 @@ another.
 - `direction`: This specifies the direction of the data mapping.
 - `just-in-time`: A bool, which indicates, if the mapping is a "just-in-time"-mapping. A JIT mapping is missing either
   the `to` or `from` tag.
-- `from_mesh`: The mesh as specified in the `from=“”` tag
-- `to_mesh`: The mesh as specified in the `to=“”` tag
+- `type`: The type of the mesh as specified by `<mapping:type .../>`
+- `constraint`: The constraint as specified in the `constraint=“”` tag.
+- `from_mesh`: The mesh as specified in the `from=“”` tag, if any.
+- `to_mesh`: The mesh as specified in the `to=“”` tag, if any.
 
 ## WriteData
 

--- a/precice_config_graph/nodes.py
+++ b/precice_config_graph/nodes.py
@@ -192,10 +192,13 @@ class DataNode:
 
 class MappingNode:
     def __init__(self, parent_participant: ParticipantNode, direction: Direction, just_in_time: bool,
-                 from_mesh: MeshNode | None = None, to_mesh: MeshNode | None = None):
+                 type: MappingType, constraint: MappingConstraint, from_mesh: MeshNode | None = None,
+                 to_mesh: MeshNode | None = None):
         self.parent_participant = parent_participant
         self.direction = direction
         self.just_in_time = just_in_time
+        self.type = type
+        self.constraint = constraint
         self.from_mesh = from_mesh
         self.to_mesh = to_mesh
 

--- a/precice_config_graph/nodes.py
+++ b/precice_config_graph/nodes.py
@@ -11,6 +11,26 @@ from __future__ import annotations
 from enum import Enum
 
 
+class MappingType(Enum):
+    NEAREST_NEIGHBOR = "nearest-neighbor"
+    NEAREST_PROJECTION = "nearest-projection"
+    NEAREST_NEIGHBOR_GRADIENT = "nearest-neighbor-gradient"
+    LINEAR_CELL_INTERPOLATION = "linear-cell-interpolation"
+    RBF_GLOBAL_ITERATIVE = "rbf-global-iterative"
+    RBF_GLOBAL_DIRECT = "rbf-global-direct"
+    RBF_PUM_DIRECT = "rbf-pum-direct"
+    RBF = "rbf"
+    AXIAL_GEOMETRIC_MULTISCALE = "axial-geometric-multiscale"
+    RADIAL_GEOMETRIC_MULTISCALE = "radial-geometric-multiscale"
+
+
+class MappingConstraint(Enum):
+    CONSERVATIVE = "conservative"
+    CONSISTENT = "consistent"
+    SCALED_CONSISTENT_SURFACE = "scaled-consistent-surface"
+    SCALED_CONSISTENT_VOLUME = "scaled-consistent-volume"
+
+
 class M2NType(Enum):
     SOCKETS = "sockets"
     MPI = "mpi"
@@ -171,8 +191,8 @@ class DataNode:
 
 
 class MappingNode:
-    def __init__(self, parent_participant: ParticipantNode, direction: Direction, just_in_time:bool,
-                 from_mesh: MeshNode|None = None, to_mesh: MeshNode|None = None):
+    def __init__(self, parent_participant: ParticipantNode, direction: Direction, just_in_time: bool,
+                 from_mesh: MeshNode | None = None, to_mesh: MeshNode | None = None):
         self.parent_participant = parent_participant
         self.direction = direction
         self.just_in_time = just_in_time

--- a/tests/example-configs/actions/actions_test.py
+++ b/tests/example-configs/actions/actions_test.py
@@ -3,7 +3,9 @@ import networkx as nx
 from precice_config_graph import graph, xml_processing
 from precice_config_graph import nodes as n
 from precice_config_graph.edges import Edge
-from precice_config_graph.nodes import DataType, Direction, TimingType, CouplingSchemeType, ActionType, M2NType
+from precice_config_graph.nodes import DataType, Direction, TimingType, CouplingSchemeType, ActionType, M2NType, \
+    MappingConstraint, MappingType
+
 
 def test_graph():
     xml = xml_processing.parse_file("tests/example-configs/actions/precice-config.xml")
@@ -42,7 +44,8 @@ def test_graph():
     )
 
     n_mapping = n.MappingNode(
-        n_propagator_participant, Direction.READ, False, from_mesh=n_generator_mesh, to_mesh=n_propagator_mesh
+        n_propagator_participant, Direction.READ, False, MappingType.NEAREST_NEIGHBOR,
+        MappingConstraint.CONSISTENT, from_mesh=n_generator_mesh, to_mesh=n_propagator_mesh
     )
     n_propagator_participant.mappings.append(n_mapping)
 
@@ -91,7 +94,8 @@ def test_graph():
     )
 
     n_exchange = n.ExchangeNode(
-        coupling_scheme=n_coupling_scheme, data=n_color, mesh=n_generator_mesh, from_participant=n_generator_participant,
+        coupling_scheme=n_coupling_scheme, data=n_color, mesh=n_generator_mesh,
+        from_participant=n_generator_participant,
         to_participant=n_propagator_participant,
     )
     n_coupling_scheme.exchanges.append(n_exchange)
@@ -111,14 +115,11 @@ def test_graph():
     for (node_a, node_b, attr) in edges:
         G_expected.add_edge(node_a, node_b, attr=attr)
 
-
     def node_match(node_a, node_b):
         return node_a == node_b
 
-
     def edge_match(edge_a, edge_b):
         return edge_a['attr'] == edge_b['attr']
-
 
     assert nx.is_isomorphic(G_expected, G_actual, node_match=node_match, edge_match=edge_match), \
         f"Graphs did not match: {nx.to_dict_of_dicts(G_actual)}, {nx.to_dict_of_dicts(G_expected)}"

--- a/tests/example-configs/simple-good/simple-good_test.py
+++ b/tests/example-configs/simple-good/simple-good_test.py
@@ -3,7 +3,7 @@ import networkx as nx
 from precice_config_graph import graph, xml_processing
 from precice_config_graph import nodes as n
 from precice_config_graph.edges import Edge
-from precice_config_graph.nodes import DataType, Direction, CouplingSchemeType, M2NType
+from precice_config_graph.nodes import DataType, Direction, CouplingSchemeType, M2NType, MappingType, MappingConstraint
 
 
 def test_graph():
@@ -42,7 +42,9 @@ def test_graph():
     n_participant_propagator.receive_meshes = [n_receive_mesh_propagator_generator_mesh_generator]
 
     # Mappings
-    n_mapping_propagator = n.MappingNode(n_participant_propagator, Direction.READ, n_mesh_generator, n_mesh_propagator)
+    n_mapping_propagator = n.MappingNode(n_participant_propagator, Direction.READ, False,
+                                         MappingType.NEAREST_NEIGHBOR, MappingConstraint.CONSISTENT,
+                                         n_mesh_generator, n_mesh_propagator)
     n_participant_propagator.mapping = [n_mapping_propagator]
 
     # Exchanges


### PR DESCRIPTION
In this new version, mappings will get two new attributes!

Constraints: Due to popular demand, the `constraint` of a mesh will now be stored as an attribute!

Type: The type of a mapping, as specified by `mapping:type` will also be stored! This will allow to perform checks based on the type and should greatly enhance the user experience.

This will close #63 