### PR TITLE
Process TODOs

### DIFF
--- a/docs/Nodes-and-Edges.md
+++ b/docs/Nodes-and-Edges.md
@@ -37,4 +37,4 @@
 - [x] Mapping -> Mesh (to)
 - [x] Mapping <-> Participant (which the mapping is a child of)
 - [x] Sockets: Participant (acceptor) -> Participant (connector)
-- [ ] MPI M2N: TODO
+- [x] MPI M2N:

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -227,7 +227,13 @@ def get_graph(root: etree.Element) -> nx.Graph:
         match kind:
             case "serial-explicit" | "serial-implicit" | "parallel-explicit" | "parallel-implicit":
                 # <participants />
-                participants = coupling_scheme_el.find("participants")  # TODO: Error on multiple participants tags
+                participants_list = coupling_scheme_el.findall("participants")
+                if len(participants_list) > 1:
+                    message:str = 'Multiple \'participants\' tags in \'' + coupling_scheme_el.tag + '\''
+                    error(message)
+                elif  len(participants_list) < 1:
+                    error_missing_attribute(coupling_scheme_el, 'participants')
+                participants = participants_list[0]
                 first_participant_name = get_attribute(participants, 'first')
                 first_participant = participant_nodes[first_participant_name]
                 second_participant_name = get_attribute(participants, 'second')

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -7,6 +7,7 @@ This graph was developed by Simon Wazynski, Alexander Hutter and Orlando Ackerma
 """
 
 import sys
+from enum import Enum
 import matplotlib.pyplot as plt
 import networkx as nx
 from lxml import etree
@@ -36,6 +37,25 @@ def get_graph(root: etree.Element) -> nx.Graph:
 
     def error_missing_attribute(e:etree.Element, key:str):
         message:str = 'Missing attribute \"' + key + '\" for element \"' + e.tag + '\".'
+        error(message)
+
+    def get_enum_values_as_string(enum:Enum):
+        values = list(map(lambda x: x.value, enum._member_map_.values()))
+        string:str = ''
+        size = len(values)
+        for i in range(size):
+            string += '\"' + values[i] + '\"'
+            if i < size - 2:
+                string += ', '
+            elif i == size - 2:
+                string += ' or '
+            else:
+                string += '.'
+        return string
+
+    def error_unknown_type(e:etree.Element, type:str, enum:Enum):
+        possible_types = get_enum_values_as_string(enum)
+        message:str = 'Unknown type \"' + type + '\" for element \"' + e.tag + '\".\nUse one of ' + possible_types
         error(message)
 
     def get_attribute(e:etree.Element, key:str):

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -113,10 +113,10 @@ def get_graph(root: etree.Element) -> nx.Graph:
         for (mapping_el, kind) in find_all_with_prefix(participant_el, "mapping"):
             direction = get_attribute(mapping_el, 'direction')
             # From mesh might not exist due to just-in-time mapping
-            from_mesh_name = get_attribute(mapping_el, 'from')
+            from_mesh_name =  mapping_el.get('from')
             from_mesh = mesh_nodes[from_mesh_name] if from_mesh_name else None
             # From mesh might not exist due to just-in-time mapping
-            to_mesh_name = get_attribute(mapping_el, 'to')
+            to_mesh_name =  mapping_el.get('to')
             to_mesh = mesh_nodes[to_mesh_name] if to_mesh_name else None
 
             type = MappingType(kind)
@@ -130,7 +130,7 @@ def get_graph(root: etree.Element) -> nx.Graph:
                 mapping = n.MappingNode(participant, n.Direction(direction), True, type, constraint,
                                         from_mesh, to_mesh)
             else:
-                pass  # TODO: Error on not found (from and to)
+                sys.exit(ERROR + ' (exiting graph generation) Missing attribute in \'' + mapping_el.tag + '\': << from >> and/or << to >>')
 
             participant.mappings.append(mapping)
             mapping_nodes.append(mapping)

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -168,9 +168,9 @@ def get_graph(root: etree.Element) -> nx.Graph:
                 for source_data_el in source_data_els:
                     source_data.append(data_nodes[get_attribute(source_data_el, 'name')])
 
-            kind = ActionType(kind)
+            type = ActionType(kind)
 
-            action = n.ActionNode(participant, kind, mesh, timing, target_data, source_data)
+            action = n.ActionNode(participant, type, mesh, timing, target_data, source_data)
             action_nodes.append(action)
 
         # Watch-Points

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -48,18 +48,18 @@ def get_graph(root: etree.Element) -> nx.Graph:
 
     # Data items – <data:… />
     for (data_el, kind) in find_all_with_prefix(root, "data"):  # TODO: Error on unknown kind
-        name = data_el.attrib.get('name')  # TODO: Error on not found
+        name = data_el.get('name')  # TODO: Error on not found
         node = n.DataNode(name, n.DataType(kind))
         data_nodes[name] = node
 
     # Meshes – <mesh />
     for mesh_el in root.findall("mesh"):
-        name = mesh_el.attrib.get('name')  # TODO: Error on not found
+        name = mesh_el.get('name')  # TODO: Error on not found
         mesh = n.MeshNode(name)
 
         # Data usages – <use-data />: Will be mapped to edges
         for use_data in mesh_el.findall("use-data"):
-            data_name = use_data.attrib.get('name')  # TODO: Error on not found
+            data_name = use_data.get('name')  # TODO: Error on not found
             data_node = data_nodes[data_name]
             mesh.use_data.append(data_node)
 
@@ -68,21 +68,21 @@ def get_graph(root: etree.Element) -> nx.Graph:
 
     # Participants – <participant />
     for participant_el in root.findall("participant"):
-        name = participant_el.attrib.get('name')  # TODO: Error on not found
+        name = participant_el.get('name')  # TODO: Error on not found
         participant = n.ParticipantNode(name)
 
         # Provide- and Receive-Mesh
         # <provide-mesh />
         for provide_mesh_el in participant_el.findall("provide-mesh"):
-            mesh_name = provide_mesh_el.attrib.get('name')  # TODO: Error on not found
+            mesh_name = provide_mesh_el.get('name')  # TODO: Error on not found
             participant.provide_meshes.append(mesh_nodes[mesh_name])
 
         # Read and write data
         # <write-data />
         for write_data_el in participant_el.findall("write-data"):
-            data_name = write_data_el.attrib.get('name')  # TODO: Error on not found
+            data_name = write_data_el.get('name')  # TODO: Error on not found
             data = data_nodes[data_name]
-            mesh_name = write_data_el.attrib.get('mesh')  # TODO: Error on not found
+            mesh_name = write_data_el.get('mesh')  # TODO: Error on not found
             mesh = mesh_nodes[mesh_name]
 
             write_data = n.WriteDataNode(participant, data, mesh)
@@ -92,9 +92,9 @@ def get_graph(root: etree.Element) -> nx.Graph:
         # <read-data />
         # TODO: Refactor to reduce code duplication
         for read_data_el in participant_el.findall("read-data"):
-            data_name = read_data_el.attrib.get('name')  # TODO: Error on not found
+            data_name = read_data_el.get('name')  # TODO: Error on not found
             data = data_nodes[data_name]
-            mesh_name = read_data_el.attrib.get('mesh')  # TODO: Error on not found
+            mesh_name = read_data_el.get('mesh')  # TODO: Error on not found
             mesh = mesh_nodes[mesh_name]
 
             read_data = n.ReadDataNode(participant, data, mesh)
@@ -103,16 +103,16 @@ def get_graph(root: etree.Element) -> nx.Graph:
 
         # Mapping
         for (mapping_el, kind) in find_all_with_prefix(participant_el, "mapping"):
-            direction = mapping_el.attrib.get('direction')  # TODO: Error on not found
+            direction = mapping_el.get('direction')  # TODO: Error on not found
             # From mesh might not exist due to just-in-time mapping
-            from_mesh_name = mapping_el.attrib.get('from')  # TODO: Error on not found
+            from_mesh_name = mapping_el.get('from')  # TODO: Error on not found
             from_mesh = mesh_nodes[from_mesh_name] if from_mesh_name else None
             # From mesh might not exist due to just-in-time mapping
-            to_mesh_name = mapping_el.attrib.get('to')  # TODO: Error on not found
+            to_mesh_name = mapping_el.get('to')  # TODO: Error on not found
             to_mesh = mesh_nodes[to_mesh_name] if to_mesh_name else None
 
             type = MappingType(kind)
-            constraint = MappingConstraint(mapping_el.attrib.get('constraint'))  # TODO: Error on not found
+            constraint = MappingConstraint(mapping_el.get('constraint'))  # TODO: Error on not found
 
             mapping = None
             if from_mesh and to_mesh:
@@ -136,20 +136,20 @@ def get_graph(root: etree.Element) -> nx.Graph:
         # Actions
         # <action:… />
         for (action_el, kind) in find_all_with_prefix(participant_el, "action"):
-            mesh = mesh_nodes[action_el.attrib.get('mesh')]  # TODO: Error on not found
-            timing = n.TimingType(action_el.attrib.get('timing'))  # TODO: Error on not found
+            mesh = mesh_nodes[action_el.get('mesh')]  # TODO: Error on not found
+            timing = n.TimingType(action_el.get('timing'))  # TODO: Error on not found
 
             target_data = None
             if kind in ["multiply-by-area", "divide-by-area", "summation", "python"]:
                 target_data_el = action_el.find("target-data")
                 if target_data_el is not None:
-                    target_data = data_nodes[target_data_el.attrib.get('name')]  # TODO: Error on not found
+                    target_data = data_nodes[target_data_el.get('name')]  # TODO: Error on not found
 
             source_data: list[n.DataNode] = []
             if kind in ["summation", "python"]:
                 source_data_els = action_el.findall("source-data")
                 for source_data_el in source_data_els:
-                    source_data.append(data_nodes[source_data_el.attrib.get('name')])  # TODO: Error on not found
+                    source_data.append(data_nodes[source_data_el.get('name')])  # TODO: Error on not found
 
             kind = ActionType(kind)
 
@@ -159,8 +159,8 @@ def get_graph(root: etree.Element) -> nx.Graph:
         # Watch-Points
         # <watch-point />
         for watch_point_el in participant_el.findall("watch-point"):
-            point_name = watch_point_el.attrib.get('name')  # TODO: Error on not found
-            mesh = mesh_nodes[watch_point_el.attrib.get('mesh')]  # TODO: Error on not found
+            point_name = watch_point_el.get('name')  # TODO: Error on not found
+            mesh = mesh_nodes[watch_point_el.get('mesh')]  # TODO: Error on not found
 
             watch_point = n.WatchPointNode(point_name, participant, mesh)
             watch_point_nodes.append(watch_point)
@@ -168,8 +168,8 @@ def get_graph(root: etree.Element) -> nx.Graph:
         # Watch-Integral
         # <watch-integral />
         for watch_integral_el in participant_el.findall("watch-integral"):
-            integral_name = watch_integral_el.attrib.get('name')  # TODO: Error on not found
-            mesh = mesh_nodes[watch_integral_el.attrib.get('mesh')]  # TODO: Error on not found
+            integral_name = watch_integral_el.get('name')  # TODO: Error on not found
+            mesh = mesh_nodes[watch_integral_el.get('mesh')]  # TODO: Error on not found
 
             watch_integral = n.WatchIntegralNode(integral_name, participant, mesh)
             watch_integral_nodes.append(watch_integral)
@@ -181,18 +181,18 @@ def get_graph(root: etree.Element) -> nx.Graph:
     # This can't be done in the participants loop, since it references participants which might not yet be created
     # <participant />
     for participant_el in root.findall("participant"):
-        name = participant_el.attrib.get('name')  # TODO: Error on not found
+        name = participant_el.get('name')  # TODO: Error on not found
         participant = participant_nodes[name]  # This should not fail, because we created participants before
 
         # <receive-mesh />
         for receive_mesh_el in participant_el.findall("receive-mesh"):
-            mesh_name = receive_mesh_el.attrib.get('name')  # TODO: Error on not found
+            mesh_name = receive_mesh_el.get('name')  # TODO: Error on not found
             mesh = mesh_nodes[mesh_name]
 
-            from_participant_name = receive_mesh_el.attrib.get('from')  # TODO: Error on not found
+            from_participant_name = receive_mesh_el.get('from')  # TODO: Error on not found
             from_participant = participant_nodes[from_participant_name]
 
-            api_access_str = receive_mesh_el.attrib.get('api-access')
+            api_access_str = receive_mesh_el.get('api-access')
             if api_access_str:
                 api_access = convert_string_to_bool(api_access_str)
             else:
@@ -209,9 +209,9 @@ def get_graph(root: etree.Element) -> nx.Graph:
             case "serial-explicit" | "serial-implicit" | "parallel-explicit" | "parallel-implicit":
                 # <participants />
                 participants = coupling_scheme_el.find("participants")  # TODO: Error on multiple participants tags
-                first_participant_name = participants.attrib.get('first')  # TODO: Error on not found
+                first_participant_name = participants.get('first')  # TODO: Error on not found
                 first_participant = participant_nodes[first_participant_name]
-                second_participant_name = participants.attrib.get('second')  # TODO: Error on not found
+                second_participant_name = participants.get('second')  # TODO: Error on not found
                 second_participant = participant_nodes[second_participant_name]
 
                 type = CouplingSchemeType(kind)
@@ -222,12 +222,12 @@ def get_graph(root: etree.Element) -> nx.Graph:
                 participants = []
                 # <participant name="..." />
                 for participant_el in coupling_scheme_el.findall("participant"):
-                    name = participant_el.attrib.get('name')  # TODO: Error on not found
+                    name = participant_el.get('name')  # TODO: Error on not found
                     participant = participant_nodes[name]
                     participants.append(participant)
 
                     control = ('control' in participant_el.attrib and
-                               convert_string_to_bool(participant_el.attrib.get('control')))
+                               convert_string_to_bool(participant_el.get('control')))
                     if control:
                         assert control_participant is None  # there must not be multiple control participants
                         control_participant = participant
@@ -240,13 +240,13 @@ def get_graph(root: etree.Element) -> nx.Graph:
 
         # Exchanges – <exchange />
         for exchange_el in coupling_scheme_el.findall("exchange"):
-            data_name = exchange_el.attrib.get('data')  # TODO: Error on not found
+            data_name = exchange_el.get('data')  # TODO: Error on not found
             data = data_nodes[data_name]
-            mesh_name = exchange_el.attrib.get('mesh')  # TODO: Error on not found
+            mesh_name = exchange_el.get('mesh')  # TODO: Error on not found
             mesh = mesh_nodes[mesh_name]
-            from_participant_name = exchange_el.attrib.get('from')  # TODO: Error on not found and different from first or second participant
+            from_participant_name = exchange_el.get('from')  # TODO: Error on not found and different from first or second participant
             from_participant = participant_nodes[from_participant_name]
-            to_participant_name = exchange_el.attrib.get('to')  # TODO: Error on not found and different from first or second participant
+            to_participant_name = exchange_el.get('to')  # TODO: Error on not found and different from first or second participant
             to_participant = participant_nodes[to_participant_name]
 
             exchange = n.ExchangeNode(coupling_scheme, data, mesh, from_participant, to_participant)
@@ -262,9 +262,9 @@ def get_graph(root: etree.Element) -> nx.Graph:
     # M2N – <m2n:… />
     for (m2n, kind) in find_all_with_prefix(root, "m2n"):
         type = M2NType(kind)
-        acceptor_name = m2n.attrib.get('acceptor')  # TODO: Error on not found
+        acceptor_name = m2n.get('acceptor')  # TODO: Error on not found
         acceptor = participant_nodes[acceptor_name]
-        connector_name = m2n.attrib.get('connector')  # TODO: Error on not found
+        connector_name = m2n.get('connector')  # TODO: Error on not found
         connector = participant_nodes[connector_name]
         m2n = n.M2NNode(type, acceptor, connector)
         m2n_nodes.append(m2n)

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -45,14 +45,9 @@ def get_graph(root: etree.Element) -> nx.Graph:
     def list_to_string(values:list) -> str:
         string:str = ''
         size = len(values)
-        for i in range(size):
-            string += '\"' + values[i] + '\"'
-            if i < size - 2:
-                string += ', '
-            elif i == size - 2:
-                string += ' or '
-            else:
-                string += '.'
+        for i in range(size - 2):
+            string += f'\"{values[i]}\", '
+        string += f'\"{values[size-2]}\" or \"{values[size-1]}\".'
         return string
 
     def error_unknown_type(e:etree.Element, type:str, possible_types_list:list):

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -138,7 +138,7 @@ def get_graph(root: etree.Element) -> nx.Graph:
                 mapping = n.MappingNode(participant, n.Direction(direction), True, type, constraint,
                                         from_mesh, to_mesh)
             else:
-                error_missing_attribute(mapping_el, '\'from\' or \'to\'')
+                error_missing_attribute(mapping_el, 'from\" or \"to')
 
             participant.mappings.append(mapping)
             mapping_nodes.append(mapping)

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -16,7 +16,7 @@ from .edges import Edge
 from .nodes import CouplingSchemeType, ActionType, M2NType, MappingType, MappingConstraint
 from .xml_processing import convert_string_to_bool
 
-ERROR: str = "\033[1;31m[Error]\033[0m"
+ERROR: str = "\033[1;31m[ERROR]\033[0m"
 
 def get_graph(root: etree.Element) -> nx.Graph:
     assert root.tag == "precice-configuration"
@@ -28,10 +28,19 @@ def get_graph(root: etree.Element) -> nx.Graph:
                 postfix = child.tag[child.tag.find(":") + 1:]
                 yield child, postfix
 
+    def error_missing_attribute(e:etree.Element, key:str):
+        sys.exit(ERROR
+                 + ' Exiting graph generation.\nMissing attribute {'
+                 + key
+                 + '} for element {'
+                 + e.tag
+                 + '}.\nPlease run \"precice-tools check\" for syntax errors.'
+                )
+
     def get_attribute(e:etree.Element, key:str):
         attribute = e.get(key)
         if not attribute:
-            sys.exit(ERROR + ' (exiting graph generation) Missing attribute in \'' + e.tag + '\': << ' + key + ' >>' + '\n Did you execute \'precice-tools check\'?')
+            error_missing_attribute(e, key)
         return attribute
 
     # FIND NODES
@@ -130,7 +139,7 @@ def get_graph(root: etree.Element) -> nx.Graph:
                 mapping = n.MappingNode(participant, n.Direction(direction), True, type, constraint,
                                         from_mesh, to_mesh)
             else:
-                sys.exit(ERROR + ' (exiting graph generation) Missing attribute in \'' + mapping_el.tag + '\': << from >> and/or << to >>')
+                error_missing_attribute(mapping_el, 'from | to')
 
             participant.mappings.append(mapping)
             mapping_nodes.append(mapping)

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -39,8 +39,10 @@ def get_graph(root: etree.Element) -> nx.Graph:
         message:str = 'Missing attribute \"' + key + '\" for element \"' + e.tag + '\".'
         error(message)
 
-    def get_enum_values_as_string(enum:Enum):
-        values = list(map(lambda x: x.value, enum._member_map_.values()))
+    def get_enum_values(enum:Enum) -> list:
+        return list(map(lambda x: x.value, enum._member_map_.values()))
+    
+    def list_to_string(values:list) -> str:
         string:str = ''
         size = len(values)
         for i in range(size):
@@ -53,8 +55,8 @@ def get_graph(root: etree.Element) -> nx.Graph:
                 string += '.'
         return string
 
-    def error_unknown_type(e:etree.Element, type:str, enum:Enum):
-        possible_types = get_enum_values_as_string(enum)
+    def error_unknown_type(e:etree.Element, type:str, possible_types_list:list):
+        possible_types = list_to_string(possible_types_list)
         message:str = 'Unknown type \"' + type + '\" for element \"' + e.tag + '\".\nUse one of ' + possible_types
         error(message)
 

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -47,20 +47,19 @@ def get_graph(root: etree.Element) -> nx.Graph:
     watch_integral_nodes: list[n.WatchIntegralNode] = []
 
     # Data items – <data:… />
-    for (data_el, kind) in find_all_with_prefix(root, "data"):
-        # TODO: Error on unknown kind
-        name = data_el.attrib['name']  # TODO: Error on not found
+    for (data_el, kind) in find_all_with_prefix(root, "data"):  # TODO: Error on unknown kind
+        name = data_el.attrib.get('name')  # TODO: Error on not found
         node = n.DataNode(name, n.DataType(kind))
         data_nodes[name] = node
 
     # Meshes – <mesh />
     for mesh_el in root.findall("mesh"):
-        name = mesh_el.attrib['name']  # TODO: Error on not found
+        name = mesh_el.attrib.get('name')  # TODO: Error on not found
         mesh = n.MeshNode(name)
 
         # Data usages – <use-data />: Will be mapped to edges
         for use_data in mesh_el.findall("use-data"):
-            data_name = use_data.attrib['name']  # TODO: Error on not found
+            data_name = use_data.attrib.get('name')  # TODO: Error on not found
             data_node = data_nodes[data_name]
             mesh.use_data.append(data_node)
 
@@ -69,21 +68,21 @@ def get_graph(root: etree.Element) -> nx.Graph:
 
     # Participants – <participant />
     for participant_el in root.findall("participant"):
-        name = participant_el.attrib['name']  # TODO: Error on not found
+        name = participant_el.attrib.get('name')  # TODO: Error on not found
         participant = n.ParticipantNode(name)
 
         # Provide- and Receive-Mesh
         # <provide-mesh />
         for provide_mesh_el in participant_el.findall("provide-mesh"):
-            mesh_name = provide_mesh_el.attrib['name']  # TODO: Error on not found
+            mesh_name = provide_mesh_el.attrib.get('name')  # TODO: Error on not found
             participant.provide_meshes.append(mesh_nodes[mesh_name])
 
         # Read and write data
         # <write-data />
         for write_data_el in participant_el.findall("write-data"):
-            data_name = write_data_el.attrib['name']  # TODO: Error on not found
+            data_name = write_data_el.attrib.get('name')  # TODO: Error on not found
             data = data_nodes[data_name]
-            mesh_name = write_data_el.attrib['mesh']  # TODO: Error on not found
+            mesh_name = write_data_el.attrib.get('mesh')  # TODO: Error on not found
             mesh = mesh_nodes[mesh_name]
 
             write_data = n.WriteDataNode(participant, data, mesh)
@@ -93,9 +92,9 @@ def get_graph(root: etree.Element) -> nx.Graph:
         # <read-data />
         # TODO: Refactor to reduce code duplication
         for read_data_el in participant_el.findall("read-data"):
-            data_name = read_data_el.attrib['name']  # TODO: Error on not found
+            data_name = read_data_el.attrib.get('name')  # TODO: Error on not found
             data = data_nodes[data_name]
-            mesh_name = read_data_el.attrib['mesh']  # TODO: Error on not found
+            mesh_name = read_data_el.attrib.get('mesh')  # TODO: Error on not found
             mesh = mesh_nodes[mesh_name]
 
             read_data = n.ReadDataNode(participant, data, mesh)
@@ -104,7 +103,7 @@ def get_graph(root: etree.Element) -> nx.Graph:
 
         # Mapping
         for (mapping_el, kind) in find_all_with_prefix(participant_el, "mapping"):
-            direction = mapping_el.attrib['direction']  # TODO: Error on not found
+            direction = mapping_el.attrib.get('direction')  # TODO: Error on not found
             # From mesh might not exist due to just-in-time mapping
             from_mesh_name = mapping_el.attrib.get('from')  # TODO: Error on not found
             from_mesh = mesh_nodes[from_mesh_name] if from_mesh_name else None
@@ -113,7 +112,7 @@ def get_graph(root: etree.Element) -> nx.Graph:
             to_mesh = mesh_nodes[to_mesh_name] if to_mesh_name else None
 
             type = MappingType(kind)
-            constraint = MappingConstraint(mapping_el.attrib['constraint'])
+            constraint = MappingConstraint(mapping_el.attrib.get('constraint'))  # TODO: Error on not found
 
             mapping = None
             if from_mesh and to_mesh:
@@ -137,20 +136,20 @@ def get_graph(root: etree.Element) -> nx.Graph:
         # Actions
         # <action:… />
         for (action_el, kind) in find_all_with_prefix(participant_el, "action"):
-            mesh = mesh_nodes[action_el.attrib['mesh']]
-            timing = n.TimingType(action_el.attrib['timing'])
+            mesh = mesh_nodes[action_el.attrib.get('mesh')]  # TODO: Error on not found
+            timing = n.TimingType(action_el.attrib.get('timing'))  # TODO: Error on not found
 
             target_data = None
             if kind in ["multiply-by-area", "divide-by-area", "summation", "python"]:
                 target_data_el = action_el.find("target-data")
                 if target_data_el is not None:
-                    target_data = data_nodes[target_data_el.attrib['name']]
+                    target_data = data_nodes[target_data_el.attrib.get('name')]  # TODO: Error on not found
 
             source_data: list[n.DataNode] = []
             if kind in ["summation", "python"]:
                 source_data_els = action_el.findall("source-data")
                 for source_data_el in source_data_els:
-                    source_data.append(data_nodes[source_data_el.attrib['name']])
+                    source_data.append(data_nodes[source_data_el.attrib.get('name')])  # TODO: Error on not found
 
             kind = ActionType(kind)
 
@@ -160,8 +159,8 @@ def get_graph(root: etree.Element) -> nx.Graph:
         # Watch-Points
         # <watch-point />
         for watch_point_el in participant_el.findall("watch-point"):
-            point_name = watch_point_el.attrib['name']
-            mesh = mesh_nodes[watch_point_el.attrib['mesh']]
+            point_name = watch_point_el.attrib.get('name')  # TODO: Error on not found
+            mesh = mesh_nodes[watch_point_el.attrib.get('mesh')]  # TODO: Error on not found
 
             watch_point = n.WatchPointNode(point_name, participant, mesh)
             watch_point_nodes.append(watch_point)
@@ -169,8 +168,8 @@ def get_graph(root: etree.Element) -> nx.Graph:
         # Watch-Integral
         # <watch-integral />
         for watch_integral_el in participant_el.findall("watch-integral"):
-            integral_name = watch_integral_el.attrib['name']
-            mesh = mesh_nodes[watch_integral_el.attrib['mesh']]
+            integral_name = watch_integral_el.attrib.get('name')  # TODO: Error on not found
+            mesh = mesh_nodes[watch_integral_el.attrib.get('mesh')]  # TODO: Error on not found
 
             watch_integral = n.WatchIntegralNode(integral_name, participant, mesh)
             watch_integral_nodes.append(watch_integral)
@@ -182,15 +181,15 @@ def get_graph(root: etree.Element) -> nx.Graph:
     # This can't be done in the participants loop, since it references participants which might not yet be created
     # <participant />
     for participant_el in root.findall("participant"):
-        name = participant_el.attrib['name']  # TODO: Error on not found
+        name = participant_el.attrib.get('name')  # TODO: Error on not found
         participant = participant_nodes[name]  # This should not fail, because we created participants before
 
         # <receive-mesh />
         for receive_mesh_el in participant_el.findall("receive-mesh"):
-            mesh_name = receive_mesh_el.attrib['name']  # TODO: Error on not found
+            mesh_name = receive_mesh_el.attrib.get('name')  # TODO: Error on not found
             mesh = mesh_nodes[mesh_name]
 
-            from_participant_name = receive_mesh_el.attrib['from']  # TODO: Error on not found
+            from_participant_name = receive_mesh_el.attrib.get('from')  # TODO: Error on not found
             from_participant = participant_nodes[from_participant_name]
 
             api_access_str = receive_mesh_el.attrib.get('api-access')
@@ -210,9 +209,9 @@ def get_graph(root: etree.Element) -> nx.Graph:
             case "serial-explicit" | "serial-implicit" | "parallel-explicit" | "parallel-implicit":
                 # <participants />
                 participants = coupling_scheme_el.find("participants")  # TODO: Error on multiple participants tags
-                first_participant_name = participants.attrib['first']  # TODO: Error on not found
+                first_participant_name = participants.attrib.get('first')  # TODO: Error on not found
                 first_participant = participant_nodes[first_participant_name]
-                second_participant_name = participants.attrib['second']  # TODO: Error on not found
+                second_participant_name = participants.attrib.get('second')  # TODO: Error on not found
                 second_participant = participant_nodes[second_participant_name]
 
                 type = CouplingSchemeType(kind)
@@ -223,12 +222,12 @@ def get_graph(root: etree.Element) -> nx.Graph:
                 participants = []
                 # <participant name="..." />
                 for participant_el in coupling_scheme_el.findall("participant"):
-                    name = participant_el.attrib['name']
+                    name = participant_el.attrib.get('name')  # TODO: Error on not found
                     participant = participant_nodes[name]
                     participants.append(participant)
 
                     control = ('control' in participant_el.attrib and
-                               convert_string_to_bool(participant_el.attrib['control']))
+                               convert_string_to_bool(participant_el.attrib.get('control')))
                     if control:
                         assert control_participant is None  # there must not be multiple control participants
                         control_participant = participant
@@ -241,15 +240,13 @@ def get_graph(root: etree.Element) -> nx.Graph:
 
         # Exchanges – <exchange />
         for exchange_el in coupling_scheme_el.findall("exchange"):
-            data_name = exchange_el.attrib['data']  # TODO: Error on not found
+            data_name = exchange_el.attrib.get('data')  # TODO: Error on not found
             data = data_nodes[data_name]
-            mesh_name = exchange_el.attrib['mesh']  # TODO: Error on not found
+            mesh_name = exchange_el.attrib.get('mesh')  # TODO: Error on not found
             mesh = mesh_nodes[mesh_name]
-            from_participant_name = exchange_el.attrib['from']
-            # TODO: Error on not found and different from first or second participant
+            from_participant_name = exchange_el.attrib.get('from')  # TODO: Error on not found and different from first or second participant
             from_participant = participant_nodes[from_participant_name]
-            to_participant_name = exchange_el.attrib['to']
-            # TODO: Error on not found and different from first or second participant
+            to_participant_name = exchange_el.attrib.get('to')  # TODO: Error on not found and different from first or second participant
             to_participant = participant_nodes[to_participant_name]
 
             exchange = n.ExchangeNode(coupling_scheme, data, mesh, from_participant, to_participant)
@@ -265,9 +262,9 @@ def get_graph(root: etree.Element) -> nx.Graph:
     # M2N – <m2n:… />
     for (m2n, kind) in find_all_with_prefix(root, "m2n"):
         type = M2NType(kind)
-        acceptor_name = m2n.attrib['acceptor']  # TODO: Error on not found
+        acceptor_name = m2n.attrib.get('acceptor')  # TODO: Error on not found
         acceptor = participant_nodes[acceptor_name]
-        connector_name = m2n.attrib['connector']  # TODO: Error on not found
+        connector_name = m2n.attrib.get('connector')  # TODO: Error on not found
         connector = participant_nodes[connector_name]
         m2n = n.M2NNode(type, acceptor, connector)
         m2n_nodes.append(m2n)

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -13,7 +13,6 @@ from lxml import etree
 
 from . import nodes as n
 from .edges import Edge
-from .nodes import CouplingSchemeType, ActionType, M2NType, MappingType, MappingConstraint
 from .xml_processing import convert_string_to_bool
 
 LINK_GRAPH_ISSUES: str = "\'\033[1;36mhttps://github.com/precice-forschungsprojekt/config-graph/issues\033[0m\'"
@@ -130,8 +129,8 @@ def get_graph(root: etree.Element) -> nx.Graph:
             to_mesh_name =  mapping_el.get('to')
             to_mesh = mesh_nodes[to_mesh_name] if to_mesh_name else None
 
-            type = MappingType(kind)
-            constraint = MappingConstraint(get_attribute(mapping_el, 'constraint'))
+                type = n.MappingType(kind)
+            constraint = n.MappingConstraint(get_attribute(mapping_el, 'constraint'))
 
             mapping = None
             if from_mesh and to_mesh:
@@ -170,7 +169,7 @@ def get_graph(root: etree.Element) -> nx.Graph:
                 for source_data_el in source_data_els:
                     source_data.append(data_nodes[get_attribute(source_data_el, 'name')])
 
-            type = ActionType(kind)
+                type = n.ActionType(kind)
 
             action = n.ActionNode(participant, type, mesh, timing, target_data, source_data)
             action_nodes.append(action)
@@ -239,7 +238,7 @@ def get_graph(root: etree.Element) -> nx.Graph:
                 second_participant_name = get_attribute(participants, 'second')
                 second_participant = participant_nodes[second_participant_name]
 
-                type = CouplingSchemeType(kind)
+                type = n.CouplingSchemeType(kind)  # TODO: unknown kind (multi not in CouplingSchemeType)
 
                 coupling_scheme = n.CouplingSchemeNode(type, first_participant, second_participant)
             case "multi":
@@ -286,7 +285,7 @@ def get_graph(root: etree.Element) -> nx.Graph:
 
     # M2N – <m2n:… />
     for (m2n, kind) in find_all_with_prefix(root, "m2n"):
-        type = M2NType(kind)
+            type = n.M2NType(kind)
         acceptor_name = get_attribute(m2n, 'acceptor')
         acceptor = participant_nodes[acceptor_name]
         connector_name = get_attribute(m2n, 'connector')

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -16,7 +16,6 @@ from .edges import Edge
 from .nodes import CouplingSchemeType, ActionType, M2NType, MappingType, MappingConstraint
 from .xml_processing import convert_string_to_bool
 
-ERROR: str = "\033[1;31m[ERROR]\033[0m"
 LINK_GRAPH_ISSUES: str = "\'\033[1;36mhttps://github.com/precice-forschungsprojekt/config-graph/issues\033[0m\'"
 
 def get_graph(root: etree.Element) -> nx.Graph:
@@ -29,12 +28,16 @@ def get_graph(root: etree.Element) -> nx.Graph:
                 postfix = child.tag[child.tag.find(":") + 1:]
                 yield child, postfix
 
-    def error_missing_attribute(e:etree.Element, key:str):
-        sys.exit(ERROR + ' Exiting graph generation.'
-                 + '\nMissing attribute \"' + key + '\" for element \"' + e.tag + '\".'
-                 + '\nPlease run \'precice-tools check\' for syntax errors.'
-                 + '\n\nIf you are sure this behaviour is incorrect, please leave a report at ' + LINK_GRAPH_ISSUES
+    def error(message:str):
+        sys.exit("\033[1;31m[ERROR]\033[0m Exiting graph generation."
+                 + "\n" + message
+                 + "\nPlease run \'precice-tools check\' for syntax errors."
+                 + "\n\nIf you are sure this behaviour is incorrect, please leave a report at " + LINK_GRAPH_ISSUES
                 )
+
+    def error_missing_attribute(e:etree.Element, key:str):
+        message:str = 'Missing attribute \"' + key + '\" for element \"' + e.tag + '\".'
+        error(message)
 
     def get_attribute(e:etree.Element, key:str):
         attribute = e.get(key)

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -260,9 +260,9 @@ def get_graph(root: etree.Element) -> nx.Graph:
             data = data_nodes[data_name]
             mesh_name = get_attribute(exchange_el, 'mesh')
             mesh = mesh_nodes[mesh_name]
-            from_participant_name = get_attribute(exchange_el, 'from')  # TODO: Error on different from first or second participant
+            from_participant_name = get_attribute(exchange_el, 'from')
             from_participant = participant_nodes[from_participant_name]
-            to_participant_name = get_attribute(exchange_el, 'to')  # TODO: Error on different from first or second participant
+            to_participant_name = get_attribute(exchange_el, 'to')
             to_participant = participant_nodes[to_participant_name]
 
             exchange = n.ExchangeNode(coupling_scheme, data, mesh, from_participant, to_participant)

--- a/precice_config_graph/graph.py
+++ b/precice_config_graph/graph.py
@@ -17,6 +17,7 @@ from .nodes import CouplingSchemeType, ActionType, M2NType, MappingType, Mapping
 from .xml_processing import convert_string_to_bool
 
 ERROR: str = "\033[1;31m[ERROR]\033[0m"
+LINK_GRAPH_ISSUES: str = "\'\033[1;36mhttps://github.com/precice-forschungsprojekt/config-graph/issues\033[0m\'"
 
 def get_graph(root: etree.Element) -> nx.Graph:
     assert root.tag == "precice-configuration"
@@ -29,12 +30,10 @@ def get_graph(root: etree.Element) -> nx.Graph:
                 yield child, postfix
 
     def error_missing_attribute(e:etree.Element, key:str):
-        sys.exit(ERROR
-                 + ' Exiting graph generation.\nMissing attribute {'
-                 + key
-                 + '} for element {'
-                 + e.tag
-                 + '}.\nPlease run \"precice-tools check\" for syntax errors.'
+        sys.exit(ERROR + ' Exiting graph generation.'
+                 + '\nMissing attribute \"' + key + '\" for element \"' + e.tag + '\".'
+                 + '\nPlease run \'precice-tools check\' for syntax errors.'
+                 + '\n\nIf you are sure this behaviour is incorrect, please leave a report at ' + LINK_GRAPH_ISSUES
                 )
 
     def get_attribute(e:etree.Element, key:str):
@@ -139,7 +138,7 @@ def get_graph(root: etree.Element) -> nx.Graph:
                 mapping = n.MappingNode(participant, n.Direction(direction), True, type, constraint,
                                         from_mesh, to_mesh)
             else:
-                error_missing_attribute(mapping_el, 'from | to')
+                error_missing_attribute(mapping_el, '\'from\' or \'to\'')
 
             participant.mappings.append(mapping)
             mapping_nodes.append(mapping)


### PR DESCRIPTION
All TODOs in graph.py are processed.

Primarily (#34 Test if precice-tools check already complains about missing attributes):
`Error on not found`

Other:
`Error on different from first or second participant` (Old -> Remove)
`Error on multiple participants tags`
`Error on unknown kind`
(`Refactor to reduce code duplication`) if necessary

- [x] `xyz.attrib['abc']` or `xyz.attrib.get('abc')` -> `xyz.get('abc')`
- [x] `Error on not found`
- [x] `Error on different from first or second participant`
- [x] `Error on multiple participants tags`
- [x] `Error on unknown kind`

`Refactoring to reduce code duplication` doesn't make sense in my opinion. This is because the changes between individual sections are usually small. This would just lead to a lot of `if/else` statements and make the code more confusing. What do you think?