### PR TITLE
Add convergence measure

### DIFF
--- a/precice_config_graph/edges.py
+++ b/precice_config_graph/edges.py
@@ -49,8 +49,6 @@ class Edge(Enum):
 
     # The connection between convergence-measure and coupling scheme it is part of
     CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO = "convergence-measure_belongs-to"
-    # The connection between exchange and coupling scheme it is part of
-    CONVERGENCE_MEASURE__EXCHANGE__BELONGS_TO = "convergence-measure_belongs-to"
     # convergence-measure <--> data
     CONVERGENCE_MEASURE__DATA = "convergence-measure_data"
     # convergence-measure <--> mesh

--- a/precice_config_graph/edges.py
+++ b/precice_config_graph/edges.py
@@ -47,6 +47,15 @@ class Edge(Enum):
     # acceleration data <--> acceleration
     ACCELERATION_DATA__ACCELERATION__BELONGS_TO = "acceleration-data_belongs-to"
 
+    # The connection between convergence-measure and coupling scheme it is part of
+    CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO = "convergence-measure_belongs-to"
+    # The connection between exchange and coupling scheme it is part of
+    CONVERGENCE_MEASURE__EXCHANGE__BELONGS_TO = "convergence-measure_belongs-to"
+    # convergence-measure <--> data
+    CONVERGENCE_MEASURE__DATA = "convergence-measure_data"
+    # convergence-measure <--> mesh
+    CONVERGENCE_MEASURE__MESH = "convergence-measure_mesh"
+
     # m2n edges
     # m2n <--> acceptor
     M2N__PARTICIPANT_ACCEPTOR = "m2n_participant-acceptor"

--- a/precice_config_graph/nodes.py
+++ b/precice_config_graph/nodes.py
@@ -83,10 +83,10 @@ class AccelerationType(Enum):
 
 
 class ConvergenceMeasureType(Enum):
-    ABSOLUTE = "absolute-convergence-measure"
-    ABSOLUTE_OR_RELATIVE = "absolute-or-relative-convergence-measure"
-    RELATIVE = "relative-convergence-measure"
-    RESIDUAL_RELATIVE = "residual-relative-convergence-measure"
+    ABSOLUTE = "absolute"
+    ABSOLUTE_OR_RELATIVE = "absolute-or-relative"
+    RELATIVE = "relative"
+    RESIDUAL_RELATIVE = "residual-relative"
 
 
 class ParticipantNode:
@@ -259,18 +259,12 @@ class ExchangeNode:
                  data: DataNode,
                  mesh: MeshNode,
                  from_participant: ParticipantNode,
-                 to_participant: ParticipantNode,
-                 convergence_measures: list[ConvergenceMeasureNode] = None):
+                 to_participant: ParticipantNode):
         self.coupling_scheme = coupling_scheme
         self.data = data
         self.mesh = mesh
         self.from_participant = from_participant
         self.to_participant = to_participant
-
-        if convergence_measures is None:
-            self.convergence_measures = []
-        else:
-            self.convergence_measures = convergence_measures
 
 
 class ExportNode:
@@ -339,10 +333,8 @@ class AccelerationNode:
 class ConvergenceMeasureNode:
     def __init__(self, type: ConvergenceMeasureType,
                  coupling_scheme: CouplingSchemeNode | MultiCouplingSchemeNode,
-                 exchange: ExchangeNode,
                  data: DataNode, mesh: MeshNode):
         self.type = type
         self.coupling_scheme = coupling_scheme
-        self.exchange = exchange
         self.data = data
         self.mesh = mesh

--- a/precice_config_graph/nodes.py
+++ b/precice_config_graph/nodes.py
@@ -82,6 +82,13 @@ class AccelerationType(Enum):
     CONSTANT = "constant"
 
 
+class ConvergenceMeasureType(Enum):
+    ABSOLUTE = "absolute-convergence-measure"
+    ABSOLUTE_OR_RELATIVE = "absolute-or-relative-convergence-measure"
+    RELATIVE = "relative-convergence-measure"
+    RESIDUAL_RELATIVE = "residual-relative-convergence-measure"
+
+
 class ParticipantNode:
     def __init__(
             self, name: str,
@@ -165,7 +172,8 @@ class ReceiveMeshNode:
 class CouplingSchemeNode:
     def __init__(self, type: CouplingSchemeType, first_participant: ParticipantNode,
                  second_participant: ParticipantNode, exchanges: list[ExchangeNode] = None,
-                 accelerations: list[AccelerationNode] = None):
+                 accelerations: list[AccelerationNode] = None,
+                 convergence_measures: list[ConvergenceMeasureNode] = None):
         self.type = type
         self.first_participant = first_participant
         self.second_participant = second_participant
@@ -180,10 +188,16 @@ class CouplingSchemeNode:
         else:
             self.accelerations = accelerations
 
+        if convergence_measures is None:
+            self.convergence_measures = []
+        else:
+            self.convergence_measures = convergence_measures
+
 
 class MultiCouplingSchemeNode:
     def __init__(self, control_participant: ParticipantNode, participants: list[ParticipantNode] = None,
-                 exchanges: list[ExchangeNode] = None, accelerations: list[AccelerationNode] = None):
+                 exchanges: list[ExchangeNode] = None, accelerations: list[AccelerationNode] = None,
+                 convergence_measures: list[ConvergenceMeasureNode] = None):
         self.control_participant = control_participant
 
         if participants is None:
@@ -200,6 +214,11 @@ class MultiCouplingSchemeNode:
             self.accelerations = []
         else:
             self.accelerations = accelerations
+
+        if convergence_measures is None:
+            self.convergence_measures = []
+        else:
+            self.convergence_measures = convergence_measures
 
 
 class DataNode:
@@ -240,12 +259,18 @@ class ExchangeNode:
                  data: DataNode,
                  mesh: MeshNode,
                  from_participant: ParticipantNode,
-                 to_participant: ParticipantNode):
+                 to_participant: ParticipantNode,
+                 convergence_measures: list[ConvergenceMeasureNode] = None):
         self.coupling_scheme = coupling_scheme
         self.data = data
         self.mesh = mesh
         self.from_participant = from_participant
         self.to_participant = to_participant
+
+        if convergence_measures is None:
+            self.convergence_measures = []
+        else:
+            self.convergence_measures = convergence_measures
 
 
 class ExportNode:
@@ -309,3 +334,15 @@ class AccelerationNode:
             self.data = []
         else:
             self.data = data
+
+
+class ConvergenceMeasureNode:
+    def __init__(self, type: ConvergenceMeasureType,
+                 coupling_scheme: CouplingSchemeNode | MultiCouplingSchemeNode,
+                 exchange: ExchangeNode,
+                 data: DataNode, mesh: MeshNode):
+        self.type = type
+        self.coupling_scheme = coupling_scheme
+        self.exchange = exchange
+        self.data = data
+        self.mesh = mesh

--- a/tests/example-configs/multi-coupling/multi-coupling_test.py
+++ b/tests/example-configs/multi-coupling/multi-coupling_test.py
@@ -262,6 +262,36 @@ def test_graph():
                 (data_node, data_node.mesh, Edge.ACCELERATION_DATA__MESH)
                 for data_node in acceleration.data
             ]
+    
+    convergence_measure_d1 = n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_displacements1, n_mesh_solidz1)
+    convergence_measure_d2 = n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_displacements2, n_mesh_solidz2)
+    convergence_measure_d3 = n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_displacements3, n_mesh_solidz3)
+    convergence_measure_f1 = n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_forces1, n_mesh_solidz1)
+    convergence_measure_f2 = n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_forces2, n_mesh_solidz2)
+    convergence_measure_f3 = n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_forces3, n_mesh_solidz3)
+
+    edges += [
+                (convergence_measure_d1, convergence_measure_d1.coupling_scheme, Edge.CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO),
+                (convergence_measure_d2, convergence_measure_d2.coupling_scheme, Edge.CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO),
+                (convergence_measure_d3, convergence_measure_d3.coupling_scheme, Edge.CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO),
+                (convergence_measure_f1, convergence_measure_f1.coupling_scheme, Edge.CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO),
+                (convergence_measure_f2, convergence_measure_f2.coupling_scheme, Edge.CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO),
+                (convergence_measure_f3, convergence_measure_f3.coupling_scheme, Edge.CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO)
+            ] + [
+                (convergence_measure_d1, convergence_measure_d1.data, Edge.CONVERGENCE_MEASURE__DATA),
+                (convergence_measure_d2, convergence_measure_d2.data, Edge.CONVERGENCE_MEASURE__DATA),
+                (convergence_measure_d3, convergence_measure_d3.data, Edge.CONVERGENCE_MEASURE__DATA),
+                (convergence_measure_f1, convergence_measure_f1.data, Edge.CONVERGENCE_MEASURE__DATA),
+                (convergence_measure_f2, convergence_measure_f2.data, Edge.CONVERGENCE_MEASURE__DATA),
+                (convergence_measure_f3, convergence_measure_f3.data, Edge.CONVERGENCE_MEASURE__DATA)
+            ] + [
+                (convergence_measure_d1, convergence_measure_d1.mesh, Edge.CONVERGENCE_MEASURE__MESH),
+                (convergence_measure_d2, convergence_measure_d2.mesh, Edge.CONVERGENCE_MEASURE__MESH),
+                (convergence_measure_d3, convergence_measure_d3.mesh, Edge.CONVERGENCE_MEASURE__MESH),
+                (convergence_measure_f1, convergence_measure_f1.mesh, Edge.CONVERGENCE_MEASURE__MESH),
+                (convergence_measure_f2, convergence_measure_f2.mesh, Edge.CONVERGENCE_MEASURE__MESH),
+                (convergence_measure_f3, convergence_measure_f3.mesh, Edge.CONVERGENCE_MEASURE__MESH)
+            ]
 
     G_expected = nx.Graph()
     for (node_a, node_b, attr) in edges:

--- a/tests/example-configs/multi-coupling/multi-coupling_test.py
+++ b/tests/example-configs/multi-coupling/multi-coupling_test.py
@@ -263,34 +263,23 @@ def test_graph():
                 for data_node in acceleration.data
             ]
     
-    convergence_measure_d1 = n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_displacements1, n_mesh_solidz1)
-    convergence_measure_d2 = n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_displacements2, n_mesh_solidz2)
-    convergence_measure_d3 = n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_displacements3, n_mesh_solidz3)
-    convergence_measure_f1 = n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_forces1, n_mesh_solidz1)
-    convergence_measure_f2 = n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_forces2, n_mesh_solidz2)
-    convergence_measure_f3 = n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_forces3, n_mesh_solidz3)
-
+    convergence_measures = [n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_displacements1, n_mesh_solidz1),
+                           n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_displacements2, n_mesh_solidz2),
+                           n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_displacements3, n_mesh_solidz3),
+                           n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_forces1, n_mesh_solidz1),
+                           n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_forces2, n_mesh_solidz2),
+                           n.ConvergenceMeasureNode(n.ConvergenceMeasureType.RELATIVE, n_coupling_scheme, n_data_forces3, n_mesh_solidz3)
+                           ]
+    
     edges += [
-                (convergence_measure_d1, convergence_measure_d1.coupling_scheme, Edge.CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO),
-                (convergence_measure_d2, convergence_measure_d2.coupling_scheme, Edge.CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO),
-                (convergence_measure_d3, convergence_measure_d3.coupling_scheme, Edge.CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO),
-                (convergence_measure_f1, convergence_measure_f1.coupling_scheme, Edge.CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO),
-                (convergence_measure_f2, convergence_measure_f2.coupling_scheme, Edge.CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO),
-                (convergence_measure_f3, convergence_measure_f3.coupling_scheme, Edge.CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO)
+                (convergence_measure, convergence_measure.coupling_scheme, Edge.CONVERGENCE_MEASURE__COUPLING_SCHEME__BELONGS_TO)
+                for convergence_measure in convergence_measures
             ] + [
-                (convergence_measure_d1, convergence_measure_d1.data, Edge.CONVERGENCE_MEASURE__DATA),
-                (convergence_measure_d2, convergence_measure_d2.data, Edge.CONVERGENCE_MEASURE__DATA),
-                (convergence_measure_d3, convergence_measure_d3.data, Edge.CONVERGENCE_MEASURE__DATA),
-                (convergence_measure_f1, convergence_measure_f1.data, Edge.CONVERGENCE_MEASURE__DATA),
-                (convergence_measure_f2, convergence_measure_f2.data, Edge.CONVERGENCE_MEASURE__DATA),
-                (convergence_measure_f3, convergence_measure_f3.data, Edge.CONVERGENCE_MEASURE__DATA)
+                (convergence_measure, convergence_measure.data, Edge.CONVERGENCE_MEASURE__DATA)
+                for convergence_measure in convergence_measures
             ] + [
-                (convergence_measure_d1, convergence_measure_d1.mesh, Edge.CONVERGENCE_MEASURE__MESH),
-                (convergence_measure_d2, convergence_measure_d2.mesh, Edge.CONVERGENCE_MEASURE__MESH),
-                (convergence_measure_d3, convergence_measure_d3.mesh, Edge.CONVERGENCE_MEASURE__MESH),
-                (convergence_measure_f1, convergence_measure_f1.mesh, Edge.CONVERGENCE_MEASURE__MESH),
-                (convergence_measure_f2, convergence_measure_f2.mesh, Edge.CONVERGENCE_MEASURE__MESH),
-                (convergence_measure_f3, convergence_measure_f3.mesh, Edge.CONVERGENCE_MEASURE__MESH)
+                (convergence_measure, convergence_measure.mesh, Edge.CONVERGENCE_MEASURE__MESH)
+                for convergence_measure in convergence_measures
             ]
 
     G_expected = nx.Graph()


### PR DESCRIPTION
A `convergence-measure` is located in a `coupling-scheme` and belongs to an `exchange`. A `coupling-scheme` and an `exchange` can have multiple `convergence-measures`. The `data` and `mesh` of an `exchange` and a `convergence-measure` must therefore match and be located in the same `coupling-scheme`.

- [x] nodes
- [x] edges
- [x] graph

Will close: #47 